### PR TITLE
[Feature] ChefDK version attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,5 @@
 default['chef_workstation']['user'] = 'chef'
 default['chef_workstation']['password'] = 'chef'
+default['chef_workstation']['chefdk']['version'] = 'latest'
 
-default['chef_workstation']['docker']['rpm'] = "https://get.docker.com/rpm/1.7.1/centos-6/RPMS/x86_64/docker-engine-1.7.1-1.el6.x86_64.rpm" 
+default['chef_workstation']['docker']['rpm'] = "https://get.docker.com/rpm/1.7.1/centos-6/RPMS/x86_64/docker-engine-1.7.1-1.el6.x86_64.rpm"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -43,6 +43,7 @@ sudo "chef_user" do
 end
 
 chef_dk 'install' do
+  version node['chef_workstation']['chefdk']['version']
   global_shell_init true
 end
 

--- a/recipes/windows_workstation.rb
+++ b/recipes/windows_workstation.rb
@@ -40,5 +40,6 @@ group "Administrators" do
 end
 
 chef_dk 'install' do
+  version node['chef_workstation']['chefdk']['version']
   global_shell_init true
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -78,9 +78,4 @@ describe 'chef_workstation::default' do
       expect(file '/etc/selinux/config').to contain('SELINUX=disabled')
     end
   end
-
-  it 'stops and disables the iptables service' do
-    expect(service 'iptables').to_not be_running
-    expect(service 'iptables').to_not be_enabled
-  end
 end


### PR DESCRIPTION
- Add `node['chef_workstation']['chefdk']['version']`
- default is `latest`
- Removed test because it's we actually need iptables
